### PR TITLE
Fix SDDM scaling

### DIFF
--- a/scripts/configure_sddm.sh
+++ b/scripts/configure_sddm.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sed -i 's/layer-shell/layer-shell,QT_SCREEN_SCALE_FACTORS=2,QT_FONT_DPI=192/g' /usr/lib/sddm/sddm.conf.d/plasma-wayland.conf
+sed -i 's/layer-shell/layer-shell,QT_FONT_DPI=144/g' /usr/lib/sddm/sddm.conf.d/plasma-wayland.conf


### PR DESCRIPTION
If `QT_SCREEN_SCALE_FACTORS` is set, Maliit doesn't show up anymore.