### PR TITLE
Disable Convergent Windows

### DIFF
--- a/etc/xdg/kwinrc
+++ b/etc/xdg/kwinrc
@@ -1,6 +1,13 @@
+[org.kde.kdecoration2]
+ButtonsOnRight=
+
 [Plugins]
-convergentwindowsEnabled=true
+convergentwindowsEnabled=false
 
 [Wayland]
 InputMethod[$e]=/usr/share/applications/com.github.maliit.keyboard.desktop
 VirtualKeyboardEnabled=true
+
+[Windows]
+BorderlessMaximizedWindows=true
+Placement=Maximizing


### PR DESCRIPTION
While Convergent Windows is nice if an external screen is connected, it has some limitations:
- GTK applications still show titlebar buttons.
- Windows are maximized in a second step after they have been opened. This doesn't look smooth.

These limitations cannot be fixed in Convergent Windows.

Disable Convergent Windows in favor of a smoother experience if no external screen is connected (should be the vast majority of cases).