### PR TITLE
Fix: Flatpak windows not maximized

### DIFF
--- a/etc/xdg/kwinrc
+++ b/etc/xdg/kwinrc
@@ -3,7 +3,7 @@ NoPlugin=true
 ButtonsOnRight=
 
 [Plugins]
-convergentwindowsEnabled=false
+convergentwindowsEnabled=true
 
 [Wayland]
 InputMethod[$e]=/usr/share/applications/com.github.maliit.keyboard.desktop


### PR DESCRIPTION
As described in [KDE bug 470010](https://bugs.kde.org/show_bug.cgi?id=470010), `Placement=Maximizing` doesn't maximize Flatpak windows properly. As a result, the panels stay transparent.

Re-enable Convergent Windows as a workaround (maximizing the windows there works).

Note: This does not bring back the general Convergent Windows functionality.